### PR TITLE
Show job affected tracks in the Jobs Table

### DIFF
--- a/World.py
+++ b/World.py
@@ -145,7 +145,27 @@ class Job():
         else:
             self.jobNotes = jobNotes
         
-    
+    def listAffectedTracks(self):
+        """
+        Returns a list of all tracks affected by this Job.
+        """
+
+        # iterate over all operations in this job
+        # list all tracks that appear as a source or destination
+        tracks = []
+        
+        for step in self.steps:
+            for op in step.operations:
+                s = op.sourceTrackName
+                d = op.destinationTrackName
+                if not (s in tracks):
+                    tracks.append(s)
+                if not (d in tracks):
+                    tracks.append(d)
+                    
+        return tracks
+        
+        
     def execute(self):
         for step in self.steps:
             step.execute()
@@ -236,7 +256,9 @@ class Operation():
         # and inserts to destination track at destinationIndex
         self.world = world
         self.sourceTrack = world.getTrackObject(sourceTrackName)
+        self.sourceTrackName = sourceTrackName
         self.destinationTrack = world.getTrackObject(destinationTrackName)
+        self.destinationTrackName = destinationTrackName
         self.count = count
         self.sourceIndex = sourceIndex
         self.destinationIndex = destinationIndex

--- a/YCUI.py
+++ b/YCUI.py
@@ -146,7 +146,7 @@ def updateJobsTable(program_state):
     values = []
     for job in jobs:
         tracks = job.listAffectedTracks()
-        trackStr = ', '.join(tracks)
+        trackStr = ' '.join(tracks)
         row = [job.jobID, 
                job.jobName, 
                '', 
@@ -1048,13 +1048,13 @@ def buildOpsTab(world):
                                     "Type",
                                     "Status",
                                     "Tracks"],
-                        col_widths = [20, 30, 10, 10, 10, 20, 20], 
+                        col_widths = [20, 30, 10, 10, 10, 50], 
                         auto_size_columns = False,
                         justification = 'center',
                         background_color = '#333333',
                         expand_x = False,
                         expand_y = True,
-                        hide_vertical_scroll = True,
+                        hide_vertical_scroll = False,
                         font = 'Consolas 10',
                         k = 'jobsTable',
                         display_row_numbers = False

--- a/YCUI.py
+++ b/YCUI.py
@@ -145,7 +145,14 @@ def updateJobsTable(program_state):
     # create table row for each job
     values = []
     for job in jobs:
-        row = [job.jobID, job.jobName, '', job.jobType, '', '']
+        tracks = job.listAffectedTracks()
+        trackStr = ', '.join(tracks)
+        row = [job.jobID, 
+               job.jobName, 
+               '', 
+               job.jobType, 
+               '', 
+               trackStr]
         values.append(row)
         
     jobsTable = mainw['jobsTable']


### PR DESCRIPTION
Adds listAffectedTracks() function to the Job object which lists all tracks affected by the Job, in chronological order.

Displays the results of Job.listAffectedTracks() in the Jobs Table.

closes #21 